### PR TITLE
Use request_cache=true to cache most frequently executed api calls.

### DIFF
--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -89,7 +89,7 @@ export class SearchService {
         }}
       }
     };
-    return this.http.post<Search[]>(this.apiUrl + this.settingsService.indexList, payLoad)
+    return this.http.post<Search[]>(this.apiUrl + this.settingsService.indexList + 'request_cache=true', payLoad)
       .pipe(catchError(this.handleError));
   }
 
@@ -145,7 +145,7 @@ export class SearchService {
       }
     };
     // const queryTerm = this.singleInput ? 'q=' + this.singleInput : '';
-    return this.http.post<Search[]>(this.apiUrl + this.settingsService.indexList, payLoad)
+    return this.http.post<Search[]>(this.apiUrl + this.settingsService.indexList + 'request_cache=true', payLoad)
       .pipe(catchError(this.handleError));
   }
 


### PR DESCRIPTION
Lisätty kahteen api-kutsuun URL-parametri request_cache=true.
[ElasticSearch dokumentaatio](https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-request-cache.html#_enabling_and_disabling_caching_per_request)