### PR TITLE
Modified production api nginx reverse proxy OpenShift template

### DIFF
--- a/nginx_reverse_proxy/api/production/nginx_api_production.yml
+++ b/nginx_reverse_proxy/api/production/nginx_api_production.yml
@@ -90,8 +90,8 @@ objects:
                 mountPath: /etc/nginx/config
         volumes:
           - name: nginx-revproxy-api-production-volume
-            configMap:
-              name: nginx-revproxy-api-production-configmap
+            secret:
+              secretName: nginx-revproxy-api-production-secret
               items:
               - key: configfile
                 path: api.conf


### PR DESCRIPTION
In production api nginx reverse proxy use OpenShift secret instead of config map.