### PR TITLE
For revproxy builds take base Docker image from internal registry

### DIFF
--- a/nginx_reverse_proxy/angular/devel-productiondata/Dockerfile
+++ b/nginx_reverse_proxy/angular/devel-productiondata/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/angular/devel-productiondata/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/angular/devel/Dockerfile
+++ b/nginx_reverse_proxy/angular/devel/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/angular/devel/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/angular/production/Dockerfile
+++ b/nginx_reverse_proxy/angular/production/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/angular/production/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/angular/qa/Dockerfile
+++ b/nginx_reverse_proxy/angular/qa/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/angular/qa/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/api/devel/Dockerfile
+++ b/nginx_reverse_proxy/api/devel/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/api/devel/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/api/production/Dockerfile
+++ b/nginx_reverse_proxy/api/production/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/api/production/nginx.conf /etc/nginx/
 EXPOSE 8080

--- a/nginx_reverse_proxy/api/qa/Dockerfile
+++ b/nginx_reverse_proxy/api/qa/Dockerfile
@@ -6,6 +6,6 @@
 # :license: MIT
 
 # Use non-root version of nginx
-FROM nginxinc/nginx-unprivileged
+FROM docker-registry.default.svc:5000/researchfi/nginx-unprivileged
 COPY nginx_reverse_proxy/api/devel/nginx.conf /etc/nginx/
 EXPOSE 8080


### PR DESCRIPTION
For revproxy builds take base Docker image from internal registry instead of Docker Hub